### PR TITLE
Possible fix for ES2015 -> ES2020 config

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,27 +1,23 @@
 import { makeRollupConfig } from "@jspsych/config/rollup";
 import esbuild from "rollup-plugin-esbuild";
 
-const config = makeRollupConfig("jsPsychPluginVoiceResponse");
-
-const newConfig = config.map((config) => {
-  if (config.output.file?.endsWith(".browser.min.js")) {
-    const modifiedConfig = {
-      ...config,
-      plugins: [
-        ...config.plugins,
-        esbuild({
-          // loaders: "json",
+const newConfig = makeRollupConfig("jsPsychPluginVoiceResponse").map((config) => {
+  // Find the IIFE config with target: "es2015"
+  if (Array.isArray(config.plugins) && config.output?.file?.endsWith(".browser.min.js")) {
+    const updatedPlugins = config.plugins.map((plugin) => {
+      // Find esbuild and replace it with target: "es2020"
+      if (plugin.name === "esbuild") {
+        return esbuild({
+          loaders: { ".json": "json" },
           minify: true,
-          target: "es2020",
-        }),
-      ],
-    };
-
-    return modifiedConfig;
-  } else {
-    return config;
+          target: "es2020"
+        });
+      }
+      return plugin;
+    });
+    return { ...config, plugins: updatedPlugins };
   }
+  return config;
 });
 
-console.log(newConfig);
 export default newConfig;


### PR DESCRIPTION
I've tried to fix the rollup config modification by adding another `.map` for the `plugins` array and replacing the esbuild config there (rather than appending another one to the `plugins` array). The build error is gone and the plugin runs for me. @teonbrooks can you let me know if this works for you?